### PR TITLE
Add the preference attribute and option for timepicker

### DIFF
--- a/src/app/atp-library/atp-time-picker.service.ts
+++ b/src/app/atp-library/atp-time-picker.service.ts
@@ -23,6 +23,7 @@ export class AmazingTimePickerService {
       rangeTime: config.rangeTime || {start: '0:0', end: '24:0'},
       arrowStyle: config.arrowStyle || {},
       locale: config.locale || 'en',
+      preference: config.preference || null
     };
     config.rangeTime = {
       start: config.rangeTime.start || '0:0',
@@ -44,7 +45,11 @@ export class AmazingTimePickerService {
     tsc.instance.appRef = this.appRef;
     tsc.instance.timerElement = '';
     tsc.instance.config = config;
-    tsc.instance.preference = Preference(config.locale);
+    if (config.preference) {
+      tsc.instance.preference = config.preference;
+    } else {
+      tsc.instance.preference = Preference(config.locale);
+    }
     tsc.instance.ParseStringToTime(config.time);
     return {
       afterClose: function () {

--- a/src/app/atp-library/atp.directive.ts
+++ b/src/app/atp-library/atp.directive.ts
@@ -20,6 +20,7 @@ export class AtpDirective {
     const start = ele.getAttribute('start');
     const end = ele.getAttribute('end');
     const locale = ele.getAttribute('locale') || 'en';
+    const preference = ele.getAttribute('preference') || null;
     let arrowStyle = ele.getAttribute('arrowStyle');
     arrowStyle = (arrowStyle) ? JSON.parse(arrowStyle.replace(new RegExp('\'', 'g'), '"')) : '';
     const timePickerFunction = this.atp.open({
@@ -27,7 +28,8 @@ export class AtpDirective {
       theme,
       rangeTime: { start, end},
       'arrowStyle': arrowStyle,
-      locale
+      locale,
+      preference
     });
     timePickerFunction.afterClose().subscribe(retTime => {
       ele.value = retTime;

--- a/src/app/atp-library/definitions.ts
+++ b/src/app/atp-library/definitions.ts
@@ -10,7 +10,7 @@ export interface TimePickerConfig {
   rangeTime?: RangeTime;
   arrowStyle?: Pallete;
   locale?: string;
-  // preference?: IDisplayPreference;
+  preference?: IDisplayPreference;
 }
 
 export interface RangeTime {


### PR DESCRIPTION
Here you will be able to pass `preference` as a attribute to the atp-time-picker directive, and also it's available in `TimePickerConfig`.
