### PR TITLE
Change to minutes after selecting the hour.

### DIFF
--- a/src/app/atp-library/atp-time-picker.service.ts
+++ b/src/app/atp-library/atp-time-picker.service.ts
@@ -23,6 +23,7 @@ export class AmazingTimePickerService {
       rangeTime: config.rangeTime || {start: '0:0', end: '24:0'},
       arrowStyle: config.arrowStyle || {},
       locale: config.locale || 'en',
+      changeToMinutes: config.changeToMinutes || false,
       preference: config.preference || null
     };
     config.rangeTime = {

--- a/src/app/atp-library/atp.directive.ts
+++ b/src/app/atp-library/atp.directive.ts
@@ -20,6 +20,7 @@ export class AtpDirective {
     const start = ele.getAttribute('start');
     const end = ele.getAttribute('end');
     const locale = ele.getAttribute('locale') || 'en';
+    const changeToMinutes = ele.getAttribute('changeToMinutes') === 'true';
     const preference = ele.getAttribute('preference') || null;
     let arrowStyle = ele.getAttribute('arrowStyle');
     arrowStyle = (arrowStyle) ? JSON.parse(arrowStyle.replace(new RegExp('\'', 'g'), '"')) : '';
@@ -29,6 +30,7 @@ export class AtpDirective {
       rangeTime: { start, end},
       'arrowStyle': arrowStyle,
       locale,
+      changeToMinutes,
       preference
     });
     timePickerFunction.afterClose().subscribe(retTime => {

--- a/src/app/atp-library/definitions.ts
+++ b/src/app/atp-library/definitions.ts
@@ -11,6 +11,7 @@ export interface TimePickerConfig {
   arrowStyle?: Pallete;
   locale?: string;
   preference?: IDisplayPreference;
+  changeToMinutes?: boolean;
 }
 
 export interface RangeTime {

--- a/src/app/atp-library/time-picker/time-picker.component.html
+++ b/src/app/atp-library/time-picker/time-picker.component.html
@@ -15,7 +15,7 @@
       </div>
     </div>
     <div class="time-picker-content">
-        <div class="time-picker-clock" (mousemove)="getDegree($event);" (mousedown)="isClicked = true;getDegree($event);" (mouseup)="isClicked = false;">
+        <div class="time-picker-clock" (mousemove)="getDegree($event);" (mousedown)="isClicked=true; getDegree($event);" (mouseup)="setTime()">
           <button *ngFor="let clock of clockObject" [ngClass]="{'active' : nowTime == clock.time}" 
             [id]="'timepicker-item-id-' + clock.time" 
             [ngStyle]="{top: clock.top,left: clock.left, color: nowTime == clock.time ? config.arrowStyle.color : config.theme == 'light' ? '#000' : '#eee', background: nowTime == clock.time ? config.arrowStyle.background : 'transparent'}">

--- a/src/app/atp-library/time-picker/time-picker.component.ts
+++ b/src/app/atp-library/time-picker/time-picker.component.ts
@@ -75,6 +75,14 @@ export class TimePickerComponent implements OnInit {
     this.degree = degrees;
   }
 
+  setTime() {
+    this.isClicked = false;
+    if (this.config.changeToMinutes && this.clockType === 'hour') {
+      this.clockType = 'minute';
+      this.clockMaker();
+    }
+  }
+
   getDegree = (ele: any) => {
     const step = this.clockType === 'minute' ? 6 : 30;
     const parrentPos = ele.currentTarget.getBoundingClientRect();


### PR DESCRIPTION
I like how other time pickers automatically change to minutes after you select the hour.

I've added a configuration option and updated the control to enable this behavior. It defaults to false, so that it won't change existing behavior. I've attempted to follow pattern, including setting the config as an HTML attribute.